### PR TITLE
implement public functions for swap lifecycle in sBTC-HashPor cross-chain atomic swap contract

### DIFF
--- a/contracts/STX-Zygelink.clar
+++ b/contracts/STX-Zygelink.clar
@@ -114,3 +114,171 @@
     (ok duration)))
 
 
+
+(define-private (validate-expiration-height (current-height uint) (duration uint))
+  (begin
+    (let ((expiration-height (+ current-height duration)))
+      (asserts! (<= expiration-height MAX-UINT) ERROR-INVALID-TOKEN-AMOUNT)
+      (ok expiration-height))))
+
+;; Private helper function
+(define-private (generate-atomic-swap-identifier)
+  (sha256 (concat 
+    (unwrap-panic (to-consensus-buff? (var-get atomic-swap-counter)))
+    (unwrap-panic (to-consensus-buff? stacks-block-height))
+  )))
+
+;; Public functions
+(define-public (initialize-atomic-swap 
+    (token-contract <ft-trait>)
+    (token-amount uint)
+    (atomic-hash-lock (buff 32))
+    (swap-duration-blocks uint)
+    (destination-blockchain (string-ascii 8))  ;; Updated parameter type
+    (destination-wallet-address (string-ascii 42)))
+  (let
+    (
+      (atomic-swap-identifier (generate-atomic-swap-identifier))
+      (transaction-sender tx-sender)
+      (current-block-height stacks-block-height)
+    )
+    ;; Validate all inputs before processing
+    (let 
+      (
+        (validated-token-amount (try! (validate-token-amount token-amount)))
+        (validated-duration (try! (validate-swap-duration swap-duration-blocks)))
+        (validated-token-principal (try! (validate-token-contract token-contract)))
+        (validated-hash-lock (try! (validate-hash-lock atomic-hash-lock)))
+        (validated-blockchain (try! (validate-blockchain-name destination-blockchain)))
+        (validated-address (try! (validate-wallet-address destination-wallet-address)))
+        (validated-expiration-height (try! (validate-expiration-height current-block-height validated-duration)))
+      )
+
+      ;; Check token balance and allowance
+      (let
+        (
+          (sender-balance (unwrap! (contract-call? token-contract get-balance transaction-sender) 
+                                  ERROR-INSUFFICIENT-TOKEN-BALANCE))
+        )
+        (asserts! (>= sender-balance validated-token-amount) ERROR-INSUFFICIENT-TOKEN-BALANCE)
+
+        ;; Transfer tokens to contract
+        (try! (contract-call? token-contract transfer 
+          validated-token-amount
+          transaction-sender
+          (as-contract tx-sender)
+          none))
+
+        ;; Create atomic swap record with validated data
+        (map-set atomic-swaps
+          { atomic-swap-identifier: atomic-swap-identifier }
+          {
+            swap-initiator: transaction-sender,
+            swap-participant: none,
+            token-contract-principal: validated-token-principal,
+            token-amount: validated-token-amount,
+            atomic-hash-lock: validated-hash-lock,
+            swap-expiration-height: validated-expiration-height,
+            swap-current-status: "active",
+            destination-blockchain: validated-blockchain,
+            destination-wallet-address: validated-address
+          }
+        )
+
+        ;; Increment atomic swap counter
+        (var-set atomic-swap-counter (+ (var-get atomic-swap-counter) u1))
+
+        (ok atomic-swap-identifier)
+      )
+    )
+  ))
+
+(define-public (register-swap-participant
+    (atomic-swap-identifier (buff 32)))
+  (let
+    (
+      (swap-details (unwrap! (get-atomic-swap-details atomic-swap-identifier) ERROR-SWAP-NOT-FOUND))
+      (transaction-sender tx-sender)
+    )
+    ;; Validate swap state
+    (asserts! (is-eq (get swap-current-status swap-details) "active") ERROR-SWAP-ALREADY-FINALIZED)
+    (asserts! (is-none (get swap-participant swap-details)) ERROR-SWAP-ALREADY-FINALIZED)
+
+    ;; Update participant
+    (map-set atomic-swaps
+      { atomic-swap-identifier: atomic-swap-identifier }
+      (merge swap-details { 
+        swap-participant: (some transaction-sender),
+        swap-current-status: "participated"
+      })
+    )
+
+    (ok true)
+  ))
+
+(define-public (redeem-atomic-swap
+    (atomic-swap-identifier (buff 32))
+    (hash-preimage (buff 32))
+    (token-contract <ft-trait>))
+  (let
+    (
+      (swap-details (unwrap! (get-atomic-swap-details atomic-swap-identifier) ERROR-SWAP-NOT-FOUND))
+      (participant (unwrap! (get swap-participant swap-details) ERROR-UNAUTHORIZED-ACCESS))
+      (validated-token-principal (try! (validate-token-contract token-contract)))
+      (current-block-height stacks-block-height)
+    )
+    ;; Validate swap state
+    (asserts! (is-eq (get swap-current-status swap-details) "participated") ERROR-SWAP-ALREADY-FINALIZED)
+    (asserts! (< current-block-height (get swap-expiration-height swap-details)) ERROR-SWAP-EXPIRED)
+    (asserts! (verify-hash-preimage hash-preimage (get atomic-hash-lock swap-details)) ERROR-UNAUTHORIZED-ACCESS)
+    (asserts! (is-eq validated-token-principal (get token-contract-principal swap-details)) ERROR-INVALID-CONTRACT)
+
+    ;; Transfer tokens to participant
+    (try! (as-contract (contract-call? token-contract transfer
+        (get token-amount swap-details)
+        tx-sender
+        participant
+        none)))
+
+    ;; Update swap status
+    (map-set atomic-swaps
+      { atomic-swap-identifier: atomic-swap-identifier }
+      (merge swap-details { swap-current-status: "redeemed" })
+    )
+
+    (ok true)
+  ))
+
+(define-public (process-swap-refund
+    (atomic-swap-identifier (buff 32))
+    (token-contract <ft-trait>))
+  (let
+    (
+      (swap-details (unwrap! (get-atomic-swap-details atomic-swap-identifier) ERROR-SWAP-NOT-FOUND))
+      (validated-token-principal (try! (validate-token-contract token-contract)))
+      (current-block-height stacks-block-height)
+    )
+    ;; Validate swap state
+    (asserts! (is-eq (get swap-current-status swap-details) "active") ERROR-SWAP-ALREADY-FINALIZED)
+    (asserts! (>= current-block-height (get swap-expiration-height swap-details)) ERROR-UNAUTHORIZED-ACCESS)
+    (asserts! (is-eq tx-sender (get swap-initiator swap-details)) ERROR-UNAUTHORIZED-ACCESS)
+    (asserts! (is-eq validated-token-principal (get token-contract-principal swap-details)) ERROR-INVALID-CONTRACT)
+
+    ;; Transfer tokens back to initiator
+    (try! (as-contract (contract-call? token-contract transfer
+        (get token-amount swap-details)
+        tx-sender
+        (get swap-initiator swap-details)
+        none)))
+
+    ;; Update swap status
+    (map-set atomic-swaps
+      { atomic-swap-identifier: atomic-swap-identifier }
+      (merge swap-details { swap-current-status: "refunded" })
+    )
+
+    (ok true)
+  ))
+
+
+


### PR DESCRIPTION

**Title:**
Implement public functions for swap lifecycle in sBTC-HashPor cross-chain atomic swap contract

---

**Description:**
This PR adds the complete set of **public functions** that govern the **atomic swap lifecycle** in the `sBTC-HashPor` contract. It includes the logic for:

1. **`initialize-atomic-swap`**

   * Initiates an atomic swap by locking tokens into the contract with a hash lock and time lock.
   * Validates all user inputs and performs token transfer after ensuring balance and contract correctness.

2. **`register-swap-participant`**

   * Allows a second party (participant) to register for the swap before redeeming.
   * Prevents duplicate participation or finalization.

3. **`redeem-atomic-swap`**

   * Lets the registered participant claim the locked tokens before expiration by revealing the correct preimage.
   * Verifies hash correctness and validates the participant’s identity and timing.

4. **`process-swap-refund`**

   * Enables the swap initiator to reclaim tokens if the swap was not completed before the expiration height.
   * Ensures only the initiator can call this after expiration and if the swap is still active.

---

**Key Features Implemented:**

* Swap lifecycle status transitions: `active → participated → redeemed` or `active → refunded`
* Strict access control for each function based on role and state
* Protection against expired, unauthorized, or already-finalized swaps
* Token transfer flows using `ft-trait` with proper contract validation

---

**Checklist:**

* [x] `initialize-atomic-swap` logic implemented with validation and token transfer
* [x] `register-swap-participant` supports one-time binding of participant
* [x] `redeem-atomic-swap` supports preimage-based secure claim
* [x] `process-swap-refund` enables time-locked recovery by initiator
* [x] All functions update on-chain state safely and atomically

---
